### PR TITLE
feat: redeemDelegationsWithText

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@metamask/delegation-toolkit": "^0.10.2",
+    "@metamask/delegation-utils": "^0.10.0",
     "@tailwindcss/postcss": "^4.1.1",
     "clipboard-copy": "^4.0.1",
     "dotenv": "^16.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@metamask/delegation-toolkit':
         specifier: ^0.10.2
         version: 0.10.2(viem@2.29.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))
+      '@metamask/delegation-utils':
+        specifier: ^0.10.0
+        version: 0.10.0(viem@2.29.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))
       '@tailwindcss/postcss':
         specifier: ^4.1.1
         version: 4.1.6

--- a/scripts/create-session-account.ts
+++ b/scripts/create-session-account.ts
@@ -1,5 +1,5 @@
 import pkg from "@metamask/delegation-toolkit";
-const { getDeleGatorEnvironment, toMetaMaskSmartAccount, Implementation, overrideDeployedEnvironment } = pkg;
+const { getDeleGatorEnvironment, toMetaMaskSmartAccount, Implementation, overrideDeployedEnvironment, createExecution, encodeExecutionCalldatas } = pkg;
 import { http, createPublicClient, encodeFunctionData, stringToHex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { createBundlerClient } from "viem/account-abstraction";
@@ -11,7 +11,7 @@ dotenv.config();
 
 // Resolves the DeleGatorEnvironment for Linea Sepolia
 const sepoliaChainId = 11155111
-const hybridDeleGatorImpl = '0x79EbfdDD65796a0ac72707C62724010b30047C11'
+const hybridDeleGatorImpl = '0xe871c23756d3b977Ef705698B238431e2D5F1B2A'
 const deploySalt = "0x";
 const privateKey = process.env.PRIVATE_KEY;
 
@@ -92,23 +92,102 @@ const setHandleDelegatorAddressData = encodeFunctionData({
 const data = setHandleDelegatorAddressData;
 console.log("data:", data);
 
-const nonce = await smartAccountCustom.getNonce();
+// const nonce = await smartAccountCustom.getNonce();
 
-const { fast: fee } = await pimlicoClient.getUserOperationGasPrice();
-console.log("fee:", fee);
+// const { fast: fee } = await pimlicoClient.getUserOperationGasPrice();
+// console.log("fee:", fee);
 
-const userOperationHash = await bundlerClient.sendUserOperation({
+// const userOperationHash = await bundlerClient.sendUserOperation({
+//     account: smartAccountCustom,
+//     verificationGasLimit: 500_000n,
+//     nonce,
+//     calls: [
+//         {
+//             to: smartAccountCustom.address,
+//             data,
+//             value: 0n
+//         }
+//     ],
+//     ...fee
+// });
+
+// console.log("User Operation Hash:", userOperationHash);
+
+const permissionData = {
+    "chainId": "0xaa36a7",
+    "address": "0x2E6c29b8E392bcF37aEc500B619EdCacF41Ff0Bf",
+    "expiry": 1747180800,
+    "isAdjustmentAllowed": true,
+    "signer": {
+        "type": "account",
+        "data": {
+            "address": "0x3E1F92b36190E03DF15b22BA18EE3AbA958dF80E"
+        }
+    },
+    "permission": {
+        "type": "native-token-stream",
+        "data": {
+            "maxAmount": "0.001",
+            "amountPerSecond": "0.000000016534391534",
+            "initialAmount": "0.0000000000000001",
+            "startTime": 1747094400,
+            "justification": "Buy tokens on your behalf when you send verified messages from Twitter."
+        }
+    },
+    "context": "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000003e1f92b36190e03df15b22ba18ee3aba958df80e0000000000000000000000002e6c29b8e392bcf37aec500b619edcacf41ff0bfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c00000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000220000000000000000000000000d10b97905a320b13a0608f7e9cc506b56747df19000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000038d7ea4c6800000000000000000000000000000000000000000000000000000000003d986caee0000000000000000000000000000000000000000000000000000000068228b80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000099f2e9bf15ce5ec84685604836f71ab835dbbded00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001046bb45c8d673d4ea75321280db34899413c069000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000006823dd00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000410f36b54d848f1805c79b90e06f471a1bb85694a7e7c671f3069d6bb4b0ae76fb29e617032f8b432584003c19935c0f1ffc51f7724c6703f01a2edbcf8c4279581c00000000000000000000000000000000000000000000000000000000000000",
+    "signerMeta": {
+        "delegationManager": "0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3"
+    }
+}
+
+const SINGLE_DEFAULT_MODE = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+
+const redeemCalldata = encodeExecutionCalldatas([
+    [createExecution(smartAccountCustom.address, 1n, "0x")]
+])
+
+const redeemDelegationsWithText = encodeFunctionData({
+    abi: [{
+        name: 'redeemDelegationsWithText',
+        type: 'function',
+        stateMutability: 'nonpayable',
+        inputs: [
+            { name: 'handle', type: 'bytes' },
+            { name: 'permissionContexts', type: 'bytes[]' },
+            { name: 'modes', type: 'bytes32[]' },
+            { name: 'calldatas', type: 'bytes[]' },
+        ],
+        outputs: []
+    }],
+    functionName: 'redeemDelegationsWithText',
+    // todo fill in individual arguments
+    args: [handleBytes, [permissionData.context as `0x${string}`], [SINGLE_DEFAULT_MODE], redeemCalldata]
+});
+
+
+const { fast: fee2 } = await pimlicoClient.getUserOperationGasPrice();
+const nonce2 = await smartAccountCustom.getNonce();
+
+
+const hash = await bundlerClient.sendUserOperation({
     account: smartAccountCustom,
-    verificationGasLimit: 500_000n,
-    nonce,
+    verificationGasLimit: 1_000_000n,
+    nonce: nonce2,
     calls: [
         {
             to: smartAccountCustom.address,
-            data,
-            value: 0n
-        }
+            data: redeemDelegationsWithText,
+            value: 0n,
+        },
     ],
-    ...fee
+    ...fee2,
 });
 
-console.log("User Operation Hash:", userOperationHash);
+console.log("hash:", hash);
+
+const { receipt } = await bundlerClient.waitForUserOperationReceipt({
+    hash,
+});
+
+console.log("receipt:", receipt);

--- a/src/components/GrantPermissionsButton.tsx
+++ b/src/components/GrantPermissionsButton.tsx
@@ -52,7 +52,8 @@ export default function GrantPermissionsButton() {
           signer: {
             type: "account",
             data: {
-              address: sessionAccount?.address as `0x${string}`,
+              address: "0x3E1F92b36190E03DF15b22BA18EE3AbA958dF80E",
+              // address: sessionAccount?.address as `0x${string}`,
             },
           },
           permission: {
@@ -68,6 +69,7 @@ export default function GrantPermissionsButton() {
           },
         },
       ]);
+      console.log("permissions:", permissions);
       savePermission(permissions[0]);
     } catch (error) {
       console.error("Error granting permissions:", error);
@@ -77,19 +79,19 @@ export default function GrantPermissionsButton() {
   };
 
   return (
-      <button
-        className="w-full cursor-pointer mt-[18px] mb-[25px] bg-[#4F46E5] hover:bg-blue-700 cursor-pointer text-white font-bold font-[Roboto] p-[14px] text-[16px] rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-        onClick={handleGrantPermissions}
-        disabled={isLoading}
-      >
-        <span>
-          {isLoading ? "Granting Permissions..." : "Grant Permissions"}
-        </span>
-        {isLoading ? (
-          <Loader2 className="h-5 w-5 animate-spin" />
-        ) : (
-          <CheckCircle className="h-5 w-5" />
-        )}
-      </button>
+    <button
+      className="w-full cursor-pointer mt-[18px] mb-[25px] bg-[#4F46E5] hover:bg-blue-700 cursor-pointer text-white font-bold font-[Roboto] p-[14px] text-[16px] rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
+      onClick={handleGrantPermissions}
+      disabled={isLoading}
+    >
+      <span>
+        {isLoading ? "Granting Permissions..." : "Grant Permissions"}
+      </span>
+      {isLoading ? (
+        <Loader2 className="h-5 w-5 animate-spin" />
+      ) : (
+        <CheckCircle className="h-5 w-5" />
+      )}
+    </button>
   );
 }


### PR DESCRIPTION
This demonstrates redeeming a delegation via a custom function [redeemDelegationsWithText](https://github.com/locker-labs/delegation-framework/pull/1/files#diff-bc98c19390bd471dda2f5f0c667535231d2d3e1df6732c2c63def34dcb52fa7dR178).

This is just a proof of concept and needs to be run in steps.
1. Run the webapp (`pnpm dev`) and create a permission
2. Copy the permission output to `permissionData` in create-session-account.
3. `ts-node scripts/create-session-account.ts` should successfully redeem the delegation
4. Change `handleBytes` in redeemDelegationsWithText to some other value. Rerun the script. It should fail.