### PR TITLE
feat: custom delegation (redeemDelegationsWithText)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,12 @@
 NEXT_PUBLIC_PIMLICO_API_KEY=pim_<your-api-key>
 NEXT_PUBLIC_RPC_URL=https://sepolia.infura.io/v3/<project-id>
-NEXT_PUBLIC_LOCKER_DELEGATE_ADDRESS=0x<your-delegate-address>
 NEXT_PUBLIC_TWITTER_CLIENT_ID=<your-twitter-client-id>
 TWITTER_CLIENT_SECRET=
 NEXT_PUBLIC_BASE_URL=https://ngrok-or-public-url
-NEXT_PUBLIC_POLL_INTERVAL_MS=1000
+NEXT_PUBLIC_POLL_INTERVAL_MS=5000
 NEXT_PUBLIC_SOCIALDATA_API_KEY=<your-socialdata-api-key>
-NEXT_PUBLIC_PRIV_KEY_SESSION_ACC=0x<your-private-key> 
+NEXT_PUBLIC_PRIVATE_KEY=0x<your-session-account-owner-private-key>
+
+# backend
+PRIVATE_KEY==0x<your-session-account-owner-private-key>
+PIMLICO_API_KEY=pim_<your-api-key>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@metamask/delegation-toolkit": "^0.10.2",
+    "@metamask/delegation-utils": "^0.10.0",
     "@tailwindcss/postcss": "^4.1.1",
     "clipboard-copy": "^4.0.1",
     "dotenv": "^16.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@metamask/delegation-toolkit':
         specifier: ^0.10.2
         version: 0.10.2(viem@2.29.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))
+      '@metamask/delegation-utils':
+        specifier: ^0.10.0
+        version: 0.10.0(viem@2.29.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))
       '@tailwindcss/postcss':
         specifier: ^4.1.1
         version: 4.1.6

--- a/scripts/create-session-account.ts
+++ b/scripts/create-session-account.ts
@@ -9,6 +9,8 @@ import { createPimlicoClient } from "permissionless/clients/pimlico";
 import dotenv from "dotenv";
 dotenv.config();
 
+const delegatorAddress = '0x29DCAbCFeD2F3AbdD8D097521032Df9f9936dC4f';
+
 // Resolves the DeleGatorEnvironment for Linea Sepolia
 const sepoliaChainId = 11155111
 const hybridDeleGatorImpl = '0xe871c23756d3b977Ef705698B238431e2D5F1B2A'
@@ -42,6 +44,7 @@ const smartAccountOg = await toMetaMaskSmartAccount({
 });
 
 console.log("smartAccountOg:", smartAccountOg.address);
+// 0xB031Cacdb585e8E49b1cEADfB125a9606a976418
 
 // Now override the environment to use the custom implementation
 overrideDeployedEnvironment(
@@ -59,6 +62,7 @@ const smartAccountCustom = await toMetaMaskSmartAccount({
 });
 
 console.log("smartAccountCustom:", smartAccountCustom.address);
+// 0x3620DD4dFa2207D85C88286F2655e0f6E12EDb27
 
 const rpcUrl = `https://public.pimlico.io/v2/${sepoliaChainId}/rpc?apikey=${process.env.PIMLICO_API_KEY}`;
 export const bundlerClient = createBundlerClient({
@@ -86,7 +90,7 @@ const setHandleDelegatorAddressData = encodeFunctionData({
         outputs: []
     }],
     functionName: 'setHandleDelegatorAddress',
-    args: [handleBytes, '0x2E6c29b8E392bcF37aEc500B619EdCacF41Ff0Bf']
+    args: [handleBytes, delegatorAddress]
 });
 
 const data = setHandleDelegatorAddressData;
@@ -115,13 +119,13 @@ console.log("data:", data);
 
 const permissionData = {
     "chainId": "0xaa36a7",
-    "address": "0x2E6c29b8E392bcF37aEc500B619EdCacF41Ff0Bf",
+    "address": delegatorAddress,
     "expiry": 1747180800,
     "isAdjustmentAllowed": true,
     "signer": {
         "type": "account",
         "data": {
-            "address": "0x3E1F92b36190E03DF15b22BA18EE3AbA958dF80E"
+            "address": smartAccountCustom.address,
         }
     },
     "permission": {
@@ -191,3 +195,6 @@ const { receipt } = await bundlerClient.waitForUserOperationReceipt({
 });
 
 console.log("receipt:", receipt);
+
+console.log('exiting...')
+process.exit(0)

--- a/scripts/create-session-account.ts
+++ b/scripts/create-session-account.ts
@@ -1,5 +1,5 @@
 import pkg from "@metamask/delegation-toolkit";
-const { getDeleGatorEnvironment, toMetaMaskSmartAccount, Implementation, overrideDeployedEnvironment } = pkg;
+const { getDeleGatorEnvironment, toMetaMaskSmartAccount, Implementation, overrideDeployedEnvironment, createExecution, encodeExecutionCalldatas } = pkg;
 import { http, createPublicClient, encodeFunctionData, stringToHex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { createBundlerClient } from "viem/account-abstraction";
@@ -11,7 +11,7 @@ dotenv.config();
 
 // Resolves the DeleGatorEnvironment for Linea Sepolia
 const sepoliaChainId = 11155111
-const hybridDeleGatorImpl = '0x79EbfdDD65796a0ac72707C62724010b30047C11'
+const hybridDeleGatorImpl = '0xe871c23756d3b977Ef705698B238431e2D5F1B2A'
 const deploySalt = "0x";
 const privateKey = process.env.PRIVATE_KEY;
 
@@ -92,23 +92,102 @@ const setHandleDelegatorAddressData = encodeFunctionData({
 const data = setHandleDelegatorAddressData;
 console.log("data:", data);
 
-const nonce = await smartAccountCustom.getNonce();
+// const nonce = await smartAccountCustom.getNonce();
 
-const { fast: fee } = await pimlicoClient.getUserOperationGasPrice();
-console.log("fee:", fee);
+// const { fast: fee } = await pimlicoClient.getUserOperationGasPrice();
+// console.log("fee:", fee);
 
-const userOperationHash = await bundlerClient.sendUserOperation({
+// const userOperationHash = await bundlerClient.sendUserOperation({
+//     account: smartAccountCustom,
+//     verificationGasLimit: 500_000n,
+//     nonce,
+//     calls: [
+//         {
+//             to: smartAccountCustom.address,
+//             data,
+//             value: 0n
+//         }
+//     ],
+//     ...fee
+// });
+
+// console.log("User Operation Hash:", userOperationHash);
+
+const permissionData = {
+    "chainId": "0xaa36a7",
+    "address": "0x2E6c29b8E392bcF37aEc500B619EdCacF41Ff0Bf",
+    "expiry": 1747180800,
+    "isAdjustmentAllowed": true,
+    "signer": {
+        "type": "account",
+        "data": {
+            "address": "0x3E1F92b36190E03DF15b22BA18EE3AbA958dF80E"
+        }
+    },
+    "permission": {
+        "type": "native-token-stream",
+        "data": {
+            "maxAmount": "0.001",
+            "amountPerSecond": "0.000000016534391534",
+            "initialAmount": "0.0000000000000001",
+            "startTime": 1747094400,
+            "justification": "Buy tokens on your behalf when you send verified messages from Twitter."
+        }
+    },
+    "context": "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000003e1f92b36190e03df15b22ba18ee3aba958df80e0000000000000000000000002e6c29b8e392bcf37aec500b619edcacf41ff0bfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c00000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000220000000000000000000000000d10b97905a320b13a0608f7e9cc506b56747df19000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000038d7ea4c6800000000000000000000000000000000000000000000000000000000003d986caee0000000000000000000000000000000000000000000000000000000068228b80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000099f2e9bf15ce5ec84685604836f71ab835dbbded00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001046bb45c8d673d4ea75321280db34899413c069000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000006823dd00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000410f36b54d848f1805c79b90e06f471a1bb85694a7e7c671f3069d6bb4b0ae76fb29e617032f8b432584003c19935c0f1ffc51f7724c6703f01a2edbcf8c4279581c00000000000000000000000000000000000000000000000000000000000000",
+    "signerMeta": {
+        "delegationManager": "0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3"
+    }
+}
+
+const SINGLE_DEFAULT_MODE = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+
+const redeemCalldata = encodeExecutionCalldatas([
+    [createExecution(smartAccountCustom.address, 1n, "0x")]
+])
+
+const redeemDelegationsWithText = encodeFunctionData({
+    abi: [{
+        name: 'redeemDelegationsWithText',
+        type: 'function',
+        stateMutability: 'nonpayable',
+        inputs: [
+            { name: 'handle', type: 'bytes' },
+            { name: 'permissionContexts', type: 'bytes[]' },
+            { name: 'modes', type: 'bytes32[]' },
+            { name: 'calldatas', type: 'bytes[]' },
+        ],
+        outputs: []
+    }],
+    functionName: 'redeemDelegationsWithText',
+    // todo fill in individual arguments
+    args: [handleBytes, [permissionData.context as `0x${string}`], [SINGLE_DEFAULT_MODE], redeemCalldata]
+});
+
+
+const { fast: fee2 } = await pimlicoClient.getUserOperationGasPrice();
+const nonce2 = await smartAccountCustom.getNonce();
+
+
+const hash = await bundlerClient.sendUserOperation({
     account: smartAccountCustom,
-    verificationGasLimit: 500_000n,
-    nonce,
+    verificationGasLimit: 1_000_000n,
+    nonce: nonce2,
     calls: [
         {
             to: smartAccountCustom.address,
-            data,
-            value: 0n
-        }
+            data: redeemDelegationsWithText,
+            value: 0n,
+        },
     ],
-    ...fee
+    ...fee2,
 });
 
-console.log("User Operation Hash:", userOperationHash);
+console.log("hash:", hash);
+
+const { receipt } = await bundlerClient.waitForUserOperationReceipt({
+    hash,
+});
+
+console.log("receipt:", receipt);

--- a/scripts/get-handle-address.ts
+++ b/scripts/get-handle-address.ts
@@ -1,0 +1,50 @@
+import { createPublicClient, http, stringToHex, toBytes, toHex, zeroAddress } from 'viem';
+import { sepolia } from 'viem/chains';
+
+const sessionAccountAddress = '0x3620DD4dFa2207D85C88286F2655e0f6E12EDb27';
+
+const handleToAddressAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "handleToAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+];
+
+const abi = handleToAddressAbi;
+
+const client = createPublicClient({
+  chain: sepolia,
+  transport: http(),
+});
+
+const contract = {
+  address: sessionAccountAddress,
+  abi,
+} as const;
+
+const result = await client.readContract({
+  ...contract,
+  functionName: 'handleToAddress',
+  args: [stringToHex('locker_money')],
+}) as string;
+
+if (zeroAddress === result) {
+  console.log("address not found");
+}
+
+console.log("result:", result);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,11 +52,11 @@ export default function Home() {
         <StepIndicators />
         {isLoading ? <Loader /> : <ActiveStep />}
         {/* TODO: comment below */}
-        <WalletInfoContainer />
+        {/* <WalletInfoContainer /> */}
         {/* TODO: comment below */}
-        <PermissionInfo />
+        {/* <PermissionInfo /> */}
         {/* TODO: comment below */}
-        {isLoading ? <Loader /> : isFlask ? <Steps /> : <InstallFlask />}
+        {/* {isLoading ? <Loader /> : isFlask ? <Steps /> : <InstallFlask />} */}
       </main>
       <Footer />
     </div>

--- a/src/components/ActiveStep.tsx
+++ b/src/components/ActiveStep.tsx
@@ -7,20 +7,68 @@ import { useState, useEffect } from "react";
 
 import { TwitterUser } from "@/services/twitterOAuth";
 import { usePermissions } from "@/providers/PermissionProvider";
+import { getXHandleAddress } from "@/utils/getXHandle";
+import { Address, zeroAddress } from "viem";
+import { setHandleDelegatorAddress } from "@/utils/setXHandle";
+
+let _renderFlag = false;
+
+// const sampleTwitterUser = { id: '1796891124319109120', username: 'ashugeth', name: 'Ashu Gupta' }
 
 export default function ActiveStep() {
+    const [isXHandleSet, setIsXHandleSet] = useState<boolean | null>(null);
     const [startPolling, setStartPolling] = useState<boolean>(false);
+    // @dev for testing, replace null with sampleTwitterUser in next line
     const [twitterUser, setTwitterUser] = useState<TwitterUser | null>(null);
-    const { permission, removePermission } = usePermissions();
+    const { smartAccount, permission, removePermission } = usePermissions();
     const { activeStep, setActiveStep } = useSteps();
 
-    /**
-     * TODO: on getting permissions, set active step to 4
-     * 
-     */
-
+     // check if delegator address exists for xHandle on component mount
     useEffect(() => {
-        if (permission) {
+        console.log('_renderFlag', _renderFlag);
+        if (_renderFlag) {
+            return;
+        };
+        _renderFlag = true;
+        
+        (async function() {
+            if (twitterUser) {
+            if (null === isXHandleSet) {
+                const address = await getXHandleAddress(twitterUser.username);
+                if (zeroAddress === address) {
+                    setIsXHandleSet(false);
+                } else {
+                    setIsXHandleSet(true);
+                }
+            }
+            }
+        })();
+    }, []);
+
+
+    // check if delegator address exists for xHandle on getting permission
+    useEffect(() => {
+      (async function() {
+        if (permission && twitterUser) {
+          if (null === isXHandleSet) {
+            const address = await getXHandleAddress(twitterUser.username);
+            console.log(`handle: ${twitterUser.username} address: ${address}`);
+            if (zeroAddress === address) {
+                console.log('setting xHandle Delegator addresss');
+                await setHandleDelegatorAddress(twitterUser.username, smartAccount as Address);
+                setIsXHandleSet(true);
+            } else {
+                setIsXHandleSet(true);
+            }
+          }
+        }
+      })();
+    }, [permission]);
+
+
+    // calculate and set active step
+    useEffect(() => {
+        if (permission && isXHandleSet) {
             setActiveStep(4);
         } else {
             // @dev for testing, replace twitterUser with !twitterUser in next line
@@ -34,7 +82,7 @@ export default function ActiveStep() {
                 }
             }
         }
-    }, [permission, activeStep, twitterUser])
+    }, [permission, activeStep, isXHandleSet, twitterUser])
 
     function renderStep() {
         switch(activeStep) {
@@ -43,7 +91,7 @@ export default function ActiveStep() {
         case 2:
             return <ConnectTwitter setTwitterUser={setTwitterUser} />;
         case 3:
-            return <GrantPermission/>;
+            return <GrantPermission twitterUser={twitterUser} isXHandleSet={isXHandleSet} />;
         case 4:
             return <SendTweet twitterUser={twitterUser} setStartPolling={setStartPolling} startPolling={startPolling} />;
         default:

--- a/src/components/GrantPermissionsButton.tsx
+++ b/src/components/GrantPermissionsButton.tsx
@@ -52,7 +52,8 @@ export default function GrantPermissionsButton() {
           signer: {
             type: "account",
             data: {
-              address: sessionAccount?.address as `0x${string}`,
+              address: "0x3E1F92b36190E03DF15b22BA18EE3AbA958dF80E",
+              // address: sessionAccount?.address as `0x${string}`,
             },
           },
           permission: {
@@ -68,6 +69,7 @@ export default function GrantPermissionsButton() {
           },
         },
       ]);
+      console.log("permissions:", permissions);
       savePermission(permissions[0]);
     } catch (error) {
       console.error("Error granting permissions:", error);
@@ -77,19 +79,19 @@ export default function GrantPermissionsButton() {
   };
 
   return (
-      <button
-        className="w-full cursor-pointer mt-[18px] mb-[25px] bg-[#4F46E5] hover:bg-blue-700 cursor-pointer text-white font-bold font-[Roboto] p-[14px] text-[16px] rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-        onClick={handleGrantPermissions}
-        disabled={isLoading}
-      >
-        <span>
-          {isLoading ? "Granting Permissions..." : "Grant Permissions"}
-        </span>
-        {isLoading ? (
-          <Loader2 className="h-5 w-5 animate-spin" />
-        ) : (
-          <CheckCircle className="h-5 w-5" />
-        )}
-      </button>
+    <button
+      className="w-full cursor-pointer mt-[18px] mb-[25px] bg-[#4F46E5] hover:bg-blue-700 cursor-pointer text-white font-bold font-[Roboto] p-[14px] text-[16px] rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
+      onClick={handleGrantPermissions}
+      disabled={isLoading}
+    >
+      <span>
+        {isLoading ? "Granting Permissions..." : "Grant Permissions"}
+      </span>
+      {isLoading ? (
+        <Loader2 className="h-5 w-5 animate-spin" />
+      ) : (
+        <CheckCircle className="h-5 w-5" />
+      )}
+    </button>
   );
 }

--- a/src/components/GrantPermissionsButton.tsx
+++ b/src/components/GrantPermissionsButton.tsx
@@ -7,6 +7,7 @@ import { erc7715ProviderActions } from "@metamask/delegation-toolkit/experimenta
 import { usePermissions } from "@/providers/PermissionProvider";
 import { Loader2, CheckCircle } from "lucide-react";
 import { useSessionAccount } from "@/providers/SessionAccountProvider";
+import { sessionAccountAddress } from "@/config";
 
 export default function GrantPermissionsButton() {
   const { savePermission } = usePermissions();
@@ -52,8 +53,7 @@ export default function GrantPermissionsButton() {
           signer: {
             type: "account",
             data: {
-              address: "0x3E1F92b36190E03DF15b22BA18EE3AbA958dF80E",
-              // address: sessionAccount?.address as `0x${string}`,
+              address: sessionAccountAddress,
             },
           },
           permission: {

--- a/src/components/RedeemDelegation.tsx
+++ b/src/components/RedeemDelegation.tsx
@@ -7,7 +7,7 @@ import { useSessionAccount } from "@/providers/SessionAccountProvider";
 import { usePermissions } from "@/providers/PermissionProvider";
 import { Loader2, CheckCircle, ExternalLink } from "lucide-react";
 import { config } from "@/config";
-import { redeemTransaction } from "@/utils/permissionHelpers";
+import { redeemDelegationsWithText } from "@/utils/permissionHelpers";
 
 let _count = 0;
 
@@ -19,6 +19,8 @@ export default function RedeemDelegation(props: TweetData) {
     const [txHash, setTxHash] = useState<Hex | null>(null);
 
     const { createSessionAccount, sessionAccount } = useSessionAccount();
+    console.log("sessionAccount in RedeemDelegation.tsx:", sessionAccount);
+
     if (!sessionAccount) {
         createSessionAccount();
     }
@@ -30,6 +32,9 @@ export default function RedeemDelegation(props: TweetData) {
     setLoading(true);
     try {
       const { accountMeta, context, signerMeta } = permission;
+      console.log('context in RedeemDelegation.tsx:', context);
+      console.log('accountMeta in RedeemDelegation.tsx:', accountMeta);
+      console.log('signerMeta in RedeemDelegation.tsx:', signerMeta);
 
       if (!signerMeta) {
         console.error("No signer meta found");
@@ -45,13 +50,11 @@ export default function RedeemDelegation(props: TweetData) {
         return;
       }
 
-      const redeemTxHash = await redeemTransaction({
+      const redeemTxHash = await redeemDelegationsWithText({
         sessionAccount,
-        delegationManager,
-        context,
-        accountMeta,
-        tokenAddress,
-        tokenAmount
+        permissionData: permission,
+        // tokenAddress,
+        // tokenAmount
       });
 
       setTxHash(redeemTxHash);
@@ -92,16 +95,16 @@ export default function RedeemDelegation(props: TweetData) {
         </div>}
 
         <div className="space-y-6">
-          <div className="w-full bg-blue-600 cursor-pointer hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed">
+          <button onClick={handleRedeemPermission} disabled={loading} className="w-full bg-blue-600 cursor-pointer hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed">
             <span>
-              {loading ? "Processing Transaction..." : "Redeemed Delegation"}
+              {loading ? "Processing Transaction..." : "Redeem Delegation"}
             </span>
             {loading ? (
               <Loader2 className="h-5 w-5 animate-spin" />
             ) : (
               <CheckCircle className="h-5 w-5" />
             )}
-          </div>
+          </button>
         </div>
       </div>
     );

--- a/src/components/steps/ConnectTwitter.tsx
+++ b/src/components/steps/ConnectTwitter.tsx
@@ -5,7 +5,11 @@ import { Info } from "lucide-react";
 import { initiateTwitterOAuth, getCurrentTwitterUser, TwitterUser } from "@/services/twitterOAuth";
 import { useSearchParams } from "next/navigation";
 
-export default function ConnectTwitter({ setTwitterUser }: { setTwitterUser: (user: TwitterUser | null) => void }) {
+export default function ConnectTwitter({
+  setTwitterUser
+}: {
+  setTwitterUser: (user: TwitterUser | null) => void;
+}) {
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
   const searchParams = useSearchParams();
 

--- a/src/components/steps/GrantPermission.tsx
+++ b/src/components/steps/GrantPermission.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 import GrantPermissionsButton from "@/components/GrantPermissionsButton";
-import { Info } from "lucide-react";
+import { TwitterUser } from "@/services/twitterOAuth";
+import { Info, Loader2 } from "lucide-react";
+import { usePermissions } from "@/providers/PermissionProvider";
 
-export default function GrantPermission() {
+export default function GrantPermission({
+  twitterUser,
+  isXHandleSet,
+}: {
+  twitterUser: TwitterUser | null;
+  isXHandleSet: boolean | null;
+}) {
+  const { permission } = usePermissions();
+  console.log(permission)
 
     return (
       <div className={`max-w-[545px] px-[40px] flex flex-col text-center items-center border-[2px] border-[#D3D3D3] rounded-lg shadow-md overflow-hidden`}>
@@ -28,6 +38,14 @@ export default function GrantPermission() {
         </p>
 
         <GrantPermissionsButton />
+
+
+        {permission && twitterUser && !isXHandleSet && <div className="w-full mb-[25px] mx-[20px] p-[20px] border border-[#D6EAFD] bg-[#D6EAFD] rounded-lg text-left flex items-center justify-start gap-[8px]">
+          <Loader2 className="h-5 w-5 animate-spin" color="#1E90FF" />
+          <p className="text-[#1E90FF] text-[16px] font-[Roboto]">
+            Registering your xHandle with your gator account...
+          </p>
+        </div>}
     </div>
     )
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,3 +4,5 @@ export const config = {
   chain: sepolia,
   ethScanerUrl: "https://sepolia.etherscan.io",
 };
+
+export const sessionAccountAddress = '0x3620DD4dFa2207D85C88286F2655e0f6E12EDb27';

--- a/src/services/pollTwitter.ts
+++ b/src/services/pollTwitter.ts
@@ -38,9 +38,9 @@ export async function pollTwitter(userId: string) {
         // processing tweets
         for (const tweet of response.tweets) {
             // @dev comment below if block for testing
-            // if (!moment(tweet.tweet_created_at).isAfter(now)) {
-            //     continue;
-            // }
+            if (!moment(tweet.tweet_created_at).isAfter(now)) {
+                continue;
+            }
 
             if (!tweet.full_text.includes(`@${botName}`)) {
                 continue;

--- a/src/utils/getXHandle.ts
+++ b/src/utils/getXHandle.ts
@@ -1,0 +1,47 @@
+import { Address, stringToHex, zeroAddress } from 'viem';
+import { publicClient } from '@/services/publicClient';
+import { sessionAccountAddress } from '@/config';
+
+const handleToAddressAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "handleToAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+];
+
+const abi = handleToAddressAbi;
+
+const contract = {
+  address: sessionAccountAddress,
+  abi,
+} as const;
+
+export async function getXHandleAddress(handle: string) {
+
+    const result = await publicClient.readContract({
+        ...contract,
+        functionName: 'handleToAddress',
+        args: [stringToHex(handle)]
+    }) as Address;
+
+    if (zeroAddress === result) {
+        console.log("address not found");
+    }
+
+    return result;
+}

--- a/src/utils/permissionHelpers.ts
+++ b/src/utils/permissionHelpers.ts
@@ -4,6 +4,83 @@ import { publicClient } from "@/services/publicClient";
 import { pimlicoClient } from "@/services/pimlicoClient";
 import { Hex } from "viem";
 
+import * as pkg from "@metamask/delegation-toolkit";
+const { getDeleGatorEnvironment, toMetaMaskSmartAccount, Implementation, overrideDeployedEnvironment, createExecution, encodeExecutionCalldatas } = pkg;
+import { http, createPublicClient, encodeFunctionData, stringToHex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { createBundlerClient } from "viem/account-abstraction";
+import { sepolia as chain } from "viem/chains";
+import { createPimlicoClient } from "permissionless/clients/pimlico";
+
+import dotenv from "dotenv";
+dotenv.config();
+
+export async function redeemDelegationsWithText({
+  sessionAccount,
+  permissionData
+}: {
+  permissionData: any;
+  sessionAccount: MetaMaskSmartAccount;
+}) {
+
+  // Encode handle string to bytes (hex)
+  const handleBytes = stringToHex('locker_money');
+  console.log("handleBytes:", handleBytes);
+
+  const SINGLE_DEFAULT_MODE = "0x0000000000000000000000000000000000000000000000000000000000000000";
+  
+  const redeemCalldata = encodeExecutionCalldatas([
+      [createExecution(sessionAccount.address, 1n, "0x")]
+  ])
+  
+  const redeemDelegationsWithText = encodeFunctionData({
+      abi: [{
+          name: 'redeemDelegationsWithText',
+          type: 'function',
+          stateMutability: 'nonpayable',
+          inputs: [
+              { name: 'handle', type: 'bytes' },
+              { name: 'permissionContexts', type: 'bytes[]' },
+              { name: 'modes', type: 'bytes32[]' },
+              { name: 'calldatas', type: 'bytes[]' },
+          ],
+          outputs: []
+      }],
+      functionName: 'redeemDelegationsWithText',
+      // todo fill in individual arguments
+      args: [handleBytes, [permissionData.context as `0x${string}`], [SINGLE_DEFAULT_MODE], redeemCalldata]
+  });
+  
+  
+  const { fast: fee2 } = await pimlicoClient.getUserOperationGasPrice();
+  const nonce2 = await sessionAccount.getNonce();
+  
+  
+  const hash = await bundlerClient.sendUserOperation({
+      account: sessionAccount,
+      verificationGasLimit: 1_000_000n,
+      nonce: nonce2,
+      calls: [
+          {
+              to: sessionAccount.address,
+              data: redeemDelegationsWithText,
+              value: 0n,
+          },
+      ],
+      ...fee2,
+  });
+  
+  console.log("hash:", hash);
+  
+  const { receipt } = await bundlerClient.waitForUserOperationReceipt({
+      hash,
+  });
+  
+  console.log("receipt:", receipt);
+
+  return hash;
+}
+
 
 
 export const redeemTransaction = async ({

--- a/src/utils/setXHandle.ts
+++ b/src/utils/setXHandle.ts
@@ -1,0 +1,100 @@
+import * as pkg from "@metamask/delegation-toolkit";
+const { getDeleGatorEnvironment, toMetaMaskSmartAccount, Implementation, overrideDeployedEnvironment } = pkg;
+import { encodeFunctionData, stringToHex, Address, Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { publicClient } from "@/services/publicClient";
+import { pimlicoClient } from "@/services/pimlicoClient";
+import { bundlerClient } from "@/services/bundlerClient";
+import { sessionAccountAddress } from "@/config";
+
+import dotenv from "dotenv";
+dotenv.config();
+
+// Resolves the DeleGatorEnvironment for Linea Sepolia
+const sepoliaChainId = 11155111;
+const hybridDeleGatorImpl = '0xe871c23756d3b977Ef705698B238431e2D5F1B2A'
+const deploySalt = "0x";
+const privateKey = process.env.NEXT_PUBLIC_PRIVATE_KEY;
+
+if (!privateKey) {
+    throw new Error("NEXT_PUBLIC_PRIVATE_KEY environment variable is required");
+}
+
+export const owner = privateKeyToAccount(privateKey as `0x${string}`);
+
+export async function setHandleDelegatorAddress(username: string, delegatorAddress: Address): Promise<Hex> {
+    const environment = getDeleGatorEnvironment(sepoliaChainId);
+    // console.log("Environment: ", environment);
+
+    const customEnv: any = { ...environment, implementations: { ...environment.implementations, HybridDeleGatorImpl: hybridDeleGatorImpl }, };
+    // console.log("customEnv: ", customEnv);
+
+    // Now override the environment to use the custom implementation
+    overrideDeployedEnvironment(
+        sepoliaChainId,
+        "1.3.0",
+        customEnv,
+    );
+
+    const smartAccountCustom = await toMetaMaskSmartAccount({
+        client: publicClient,
+        implementation: Implementation.Hybrid,
+        deployParams: [owner.address, [], [], []],
+        deploySalt,
+        signatory: { account: owner },
+    });
+
+    console.log("smartAccountCustom.address:", smartAccountCustom.address);
+    console.log('sessionAccountAddress', sessionAccountAddress);
+
+    // Encode handle string to bytes (hex)
+    const handleBytes = stringToHex(username);
+    console.log("handleBytes:", handleBytes);
+
+    const setHandleDelegatorAddressData = encodeFunctionData({
+        abi: [{
+            name: 'setHandleDelegatorAddress',
+            type: 'function',
+            stateMutability: 'nonpayable',
+            inputs: [
+                { name: 'handle', type: 'bytes' },
+                { name: 'delegatorAddress', type: 'address' }
+            ],
+            outputs: []
+        }],
+        functionName: 'setHandleDelegatorAddress',
+        args: [handleBytes, delegatorAddress]
+    });
+
+    const data = setHandleDelegatorAddressData;
+    console.log("data:", data);
+
+    const nonce = await smartAccountCustom.getNonce();
+
+    const { fast: fee } = await pimlicoClient.getUserOperationGasPrice();
+    console.log("fee:", fee);
+
+    const userOperationHash = await bundlerClient.sendUserOperation({
+        account: smartAccountCustom,
+        verificationGasLimit: 500_000n,
+        nonce,
+        calls: [
+            {
+                to: sessionAccountAddress,
+                data,
+                value: 0n
+            }
+        ],
+        ...fee
+    });
+
+    console.log("User Operation Hash:", userOperationHash);
+    
+    const { receipt } = await bundlerClient.waitForUserOperationReceipt({
+        hash: userOperationHash,
+    });
+    
+    console.log("setHandleDelegatorAddress receipt:", receipt);
+
+    return userOperationHash;
+}


### PR DESCRIPTION
This PR integrates a new `custom session account` that allows us to make custom redeemDelegation calls by passing additional data as compared to Metamask's `sendUserOperationWithDelegation`

This PR also includes changes in #9 